### PR TITLE
Several cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,9 @@ include_directories(src)
 include_directories(include)
 set(BASKET_SRC  include/basket/common/singleton.h
                 include/basket/common/debug.h
-		include/basket/common/enumerations.h
-		include/basket/common/macros.h
-		include/basket/common/configuration_manager.h
+                include/basket/common/enumerations.h
+                include/basket/common/macros.h
+                include/basket/common/configuration_manager.h
                 src/basket/common/debug.cpp
                 include/basket/common/constants.h
                 include/basket/common/typedefs.h
@@ -49,7 +49,7 @@ set(BASKET_SRC  include/basket/common/singleton.h
                 include/basket/set/set.h
                 include/basket/sequencer/global_sequence.h
                 src/basket/sequencer/global_sequence.cpp
-        include/basket/communication/rpc_factory.h)
+                include/basket/communication/rpc_factory.h)
 
 add_library(${PROJECT_NAME} SHARED ${BASKET_SRC})
 
@@ -63,15 +63,13 @@ set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 
 configure_file(basket.pc.in basket.pc @ONLY)
 
-target_include_directories(${PROJECT_NAME} PRIVATE .)
-
 if(BASKET_ENABLE_RPCLIB)
     set(RPC_LIB_FLAGS -lrpc ${RPC_LIB_FLAGS})
 endif()
 if(BASKET_ENABLE_THALLIUM_ROCE OR BASKET_ENABLE_THALLIUM_TCP)
     set(RPC_LIB_FLAGS -lthallium -lmercury -lmercury_util -lmargo -labt ${RPC_LIB_FLAGS})
 endif()
-set(LIB_FLAGS ${RPC_LIB_FLAGS} -lmpi -lpthread -lrt -lboost_filesystem)
+set(LIB_FLAGS ${RPC_LIB_FLAGS} -lmpi -lpthread -lrt)
 
 # libs for NATS tests
 #set(LIB_FLAGS ${LIB_FLAGS} -lnats)
@@ -97,11 +95,5 @@ endif()
 option(BUILD_TEST "Build the unit tests" ON)
 if(BUILD_TEST)
     enable_testing()
-    include(CTest)
     add_subdirectory(test)
-    foreach (example ${examples})
-        add_custom_command(TARGET ${example} POST_BUILD
-                                  COMMAND ${CMAKE_COMMAND} -E copy
-                                  "" $<TARGET_FILE_DIR:${example}>)
-    endforeach()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,12 +20,10 @@ add_custom_command(
 # Compile all examples
 foreach (example ${examples})
     add_executable (${example} ${example}.cpp util.h)
-    add_dependencies(${example} basket)
+    add_dependencies(${example} ${PROJECT_NAME})
     add_dependencies(${example} copy_hostfile)
     add_dependencies(${example} copy_server_list)
-    target_include_directories(${example} PRIVATE "${CMAKE_BINARY_DIR}/")
-    set_target_properties(${example} PROPERTIES ENVIRONMENT LD_PRELOAD=${CMAKE_BINARY_DIR}/libbasket.so)
-    target_link_libraries(${example} ${LIB_FLAGS} -L${CMAKE_BINARY_DIR}/ -lbasket -lmpi)
+    target_link_libraries(${example} ${PROJECT_NAME})
     set_target_properties (${example} PROPERTIES FOLDER test)
 endforeach()
 
@@ -35,8 +33,6 @@ message(INFO ${CMAKE_BINARY_DIR}/libbasket.so)
 function(mpi target mpi_procs example ranks_per_process num_requests size_of_request server_on_node debug)
     set (test_parameters  -np ${mpi_procs} -f "${CMAKE_BINARY_DIR}/test/hostfile" "${CMAKE_BINARY_DIR}/test/${example}" ${ranks_per_process} ${num_requests} ${size_of_request} ${server_on_node} ${debug})
     add_test(NAME ${target}_${example}_MPI_${mpi_procs}_${ranks_per_process}_${num_requests}_${size_of_request}_${server_on_node}_${debug} COMMAND "mpirun" ${test_parameters})
-    set_tests_properties(${target}_${example}_MPI_${mpi_procs}_${ranks_per_process}_${num_requests}_${size_of_request}_${server_on_node}_${debug} PROPERTIES ENVIRONMENT LD_PRELOAD=${CMAKE_BINARY_DIR}/libbasket.so)
-    set_tests_properties(${target}_${example}_MPI_${mpi_procs}_${ranks_per_process}_${num_requests}_${size_of_request}_${server_on_node}_${debug} PROPERTIES WILL_FAIL true)
 endfunction()
 
 # Define MPI test case

--- a/test/map_test.cpp
+++ b/test/map_test.cpp
@@ -139,7 +139,7 @@ int main (int argc,char* argv[])
     BASKET_CONF->MY_SERVER = my_server;
     BASKET_CONF->NUM_SERVERS = num_servers;
     BASKET_CONF->SERVER_ON_NODE = server_on_node || is_server;
-    BASKET_CONF->SERVER_LIST_PATH = "./test/server_list";
+    BASKET_CONF->SERVER_LIST_PATH = "./server_list";
 
     basket::map<KeyType,std::array<int, array_size>> *map;
     if (is_server) {

--- a/test/multimap_test.cpp
+++ b/test/multimap_test.cpp
@@ -139,7 +139,7 @@ int main (int argc,char* argv[])
     BASKET_CONF->MY_SERVER = my_server;
     BASKET_CONF->NUM_SERVERS = num_servers;
     BASKET_CONF->SERVER_ON_NODE = server_on_node || is_server;
-    BASKET_CONF->SERVER_LIST_PATH = "./test/server_list";
+    BASKET_CONF->SERVER_LIST_PATH = "./server_list";
 
     basket::multimap<KeyType,std::array<int, array_size>> *multimap;
     if (is_server) {

--- a/test/priority_queue_test.cpp
+++ b/test/priority_queue_test.cpp
@@ -139,7 +139,7 @@ int main (int argc,char* argv[])
     BASKET_CONF->MY_SERVER = my_server;
     BASKET_CONF->NUM_SERVERS = num_servers;
     BASKET_CONF->SERVER_ON_NODE = server_on_node || is_server;
-    BASKET_CONF->SERVER_LIST_PATH = "./test/server_list";
+    BASKET_CONF->SERVER_LIST_PATH = "./server_list";
 
     basket::priority_queue<KeyType> *priority_queue;
     if (is_server) {

--- a/test/queue_test.cpp
+++ b/test/queue_test.cpp
@@ -139,7 +139,7 @@ int main (int argc,char* argv[])
     BASKET_CONF->MY_SERVER = my_server;
     BASKET_CONF->NUM_SERVERS = num_servers;
     BASKET_CONF->SERVER_ON_NODE = server_on_node || is_server;
-    BASKET_CONF->SERVER_LIST_PATH = "./test/server_list";
+    BASKET_CONF->SERVER_LIST_PATH = "./server_list";
 
     basket::queue<KeyType> *queue;
     if (is_server) {

--- a/test/set_test.cpp
+++ b/test/set_test.cpp
@@ -145,7 +145,7 @@ int main (int argc,char* argv[])
     BASKET_CONF->MY_SERVER = my_server;
     BASKET_CONF->NUM_SERVERS = num_servers;
     BASKET_CONF->SERVER_ON_NODE = server_on_node || is_server;
-    BASKET_CONF->SERVER_LIST_PATH = "./test/server_list";
+    BASKET_CONF->SERVER_LIST_PATH = "./server_list";
 
     basket::set<KeyType> *set;
     if (is_server) {

--- a/test/unordered_map_test.cpp
+++ b/test/unordered_map_test.cpp
@@ -137,7 +137,7 @@ int main (int argc,char* argv[])
     BASKET_CONF->MY_SERVER = my_server;
     BASKET_CONF->NUM_SERVERS = num_servers;
     BASKET_CONF->SERVER_ON_NODE = server_on_node || is_server;
-    BASKET_CONF->SERVER_LIST_PATH = "./test/server_list";
+    BASKET_CONF->SERVER_LIST_PATH = "./server_list";
 
     basket::unordered_map<KeyType,std::array<int, array_size>> *map;
     if (is_server) {


### PR DESCRIPTION
* Removed several unnecessary commands
* Fixed linking of tests with `libbasket.so` (no more `LD_PRELOAD`)
* Changed `SERVER_LIST_PATH` in tests (the tests run inside `CMAKE_BINARY_DIR/tests` when `ctest` is used).
* Removed `WILL_FAIL true` property from tests. I verified that both MPICH 3.2.1 and 3.3.1 are ok with this.
@hariharan-devarajan @Keith-Bateman 