### PR TITLE
Keep connections open

### DIFF
--- a/include/basket/communication/rpc_lib.cpp
+++ b/include/basket/communication/rpc_lib.cpp
@@ -52,20 +52,19 @@ Response RPC::callWithTimeout(uint16_t server_index, int timeout_ms, CharStruct 
     switch (BASKET_CONF->RPC_IMPLEMENTATION) {
 #ifdef BASKET_ENABLE_RPCLIB
         case RPCLIB: {
-            /* Connect to Server */
-            rpc::client client(BASKET_CONF->SERVER_LIST[server_index].c_str(), port);
-            client.set_timeout(timeout_ms);
-            return client.call(func_name.c_str(), std::forward<Args>(args)...);
+            auto *client = rpclib_clients[server_index].get();
+            client->set_timeout(timeout_ms);
+            Response response = client->call(func_name.c_str(), std::forward<Args>(args)...);
+            client->clear_timeout();
+            return response;
             break;
         }
 #endif
 #ifdef BASKET_ENABLE_THALLIUM_TCP
         case THALLIUM_TCP: {
-            /* Connect to Server */
-
             std::shared_ptr<tl::engine> thallium_client;
             if (BASKET_CONF->IS_SERVER) {
-	      thallium_client = std::make_shared<tl::engine>(BASKET_CONF->TCP_CONF.c_str(), MARGO_CLIENT_MODE);
+                thallium_client = std::make_shared<tl::engine>(BASKET_CONF->TCP_CONF.c_str(), MARGO_CLIENT_MODE);
             }
             else {
                 thallium_client = thallium_engine;
@@ -75,52 +74,27 @@ Response RPC::callWithTimeout(uint16_t server_index, int timeout_ms, CharStruct 
             // Setup args for RDMA bulk transfer
             // std::vector<std::pair<void*,std::size_t>> segments(num_args);
 
-            // We use addr lookup because mercury addresses must be exactly 15 char
-            char ip[16];
-            struct hostent *he = gethostbyname(BASKET_CONF->SERVER_LIST[server_index].c_str());
-            in_addr **addr_list = (struct in_addr **)he->h_addr_list;
-            strcpy(ip, inet_ntoa(*addr_list[0]));
-
-            CharStruct lookup_str = BASKET_CONF->TCP_CONF + "://" + std::string(ip) + ":" +
-                    std::to_string(port);
-            tl::endpoint server_endpoint = thallium_client->lookup(lookup_str.c_str());
-            return remote_procedure.on(server_endpoint)(std::forward<Args>(args)...);
+            return remote_procedure.on(thallium_endpoints[server_index])(std::forward<Args>(args)...);
             break;
         }
 #endif
 #ifdef BASKET_ENABLE_THALLIUM_ROCE
         case THALLIUM_ROCE: {
-            /* Connect to Server */
-
             std::shared_ptr<tl::engine> thallium_client;
             if (BASKET_CONF->IS_SERVER) {
-	      thallium_client = std::make_shared<tl::engine>(BASKET_CONF->VERBS_CONF.c_str(), MARGO_CLIENT_MODE);
+                thallium_client = std::make_shared<tl::engine>(BASKET_CONF->VERBS_CONF.c_str(), MARGO_CLIENT_MODE);
             }
             else {
                 thallium_client = thallium_engine;
             }
 
             tl::remote_procedure remote_procedure = thallium_client->define(func_name.c_str());
-
             // Setup args for RDMA bulk transfer
             // std::vector<std::pair<void*,std::size_t>> segments(num_args);
+            // tl::bulk bulk_handle = remote_procedure.on(server_endpoint)(std::forward<Args>(args)...);
+            // return std::make_pair(lookup_str, bulk_handle);
 
-            // We use addr lookup because mercury addresses must be exactly 15 char
-            char ip[16];
-            struct hostent *he = gethostbyname(BASKET_CONF->SERVER_LIST[server_index].c_str());
-            in_addr **addr_list = (struct in_addr **)he->h_addr_list;
-            strcpy(ip, inet_ntoa(*addr_list[0]));
-
-            CharStruct lookup_str = BASKET_CONF->VERBS_CONF + "://" + std::string(ip) + ":" +
-                    std::to_string(port);
-            tl::endpoint server_endpoint = thallium_client->lookup(lookup_str.c_str());
-            // if (func_name == "test_Get") {
-            //     tl::bulk bulk_handle = remote_procedure.on(server_endpoint)(std::forward<Args>(args)...);
-            //     return std::make_pair(lookup_str, bulk_handle);
-            // }
-            // else {
-                return remote_procedure.on(server_endpoint)(std::forward<Args>(args)...);
-            // }
+            return remote_procedure.on(thallium_endpoints[server_index])(std::forward<Args>(args)...);
             break;
         }
 #endif
@@ -132,24 +106,21 @@ Response RPC::call(uint16_t server_index,
                    Args... args) {
     AutoTrace trace = AutoTrace("RPC::call", server_index, func_name);
     int16_t port = server_port + server_index;
-    
+
     switch (BASKET_CONF->RPC_IMPLEMENTATION) {
 #ifdef BASKET_ENABLE_RPCLIB
         case RPCLIB: {
-            /* Connect to Server */
-            rpc::client client(server_list.at(server_index).c_str(), port);
+            auto *client = rpclib_clients[server_index].get();
             /*client.set_timeout(5000);*/
-            return client.call(func_name.c_str(), std::forward<Args>(args)...);
+            return client->call(func_name.c_str(), std::forward<Args>(args)...);
             break;
         }
 #endif
 #ifdef BASKET_ENABLE_THALLIUM_TCP
         case THALLIUM_TCP: {
-            /* Connect to Server */
-
             std::shared_ptr<tl::engine> thallium_client;
             if (BASKET_CONF->IS_SERVER) {
-	      thallium_client = std::make_shared<tl::engine>(BASKET_CONF->TCP_CONF.c_str(), MARGO_CLIENT_MODE);
+                thallium_client = std::make_shared<tl::engine>(BASKET_CONF->TCP_CONF.c_str(), MARGO_CLIENT_MODE);
             }
             else {
                 thallium_client = thallium_engine;
@@ -159,26 +130,15 @@ Response RPC::call(uint16_t server_index,
             // Setup args for RDMA bulk transfer
             // std::vector<std::pair<void*,std::size_t>> segments(num_args);
 
-            // We use addr lookup because mercury addresses must be exactly 15 char
-            char ip[16];
-            struct hostent *he = gethostbyname(server_list.at(server_index).c_str());
-            in_addr **addr_list = (struct in_addr **)he->h_addr_list;
-            strcpy(ip, inet_ntoa(*addr_list[0]));
-
-            CharStruct lookup_str = BASKET_CONF->TCP_CONF + "://" + std::string(ip) + ":" + 
-                    std::to_string(port);
-            tl::endpoint server_endpoint = thallium_client->lookup(lookup_str.c_str());
-            return remote_procedure.on(server_endpoint)(std::forward<Args>(args)...);
+            return remote_procedure.on(thallium_endpoints[server_index])(std::forward<Args>(args)...);
             break;
         }
 #endif
 #ifdef BASKET_ENABLE_THALLIUM_ROCE
         case THALLIUM_ROCE: {
-            /* Connect to Server */
-
             std::shared_ptr<tl::engine> thallium_client;
             if (BASKET_CONF->IS_SERVER) {
-	      thallium_client = std::make_shared<tl::engine>(BASKET_CONF->VERBS_CONF.c_str(), MARGO_CLIENT_MODE);
+                thallium_client = std::make_shared<tl::engine>(BASKET_CONF->VERBS_CONF.c_str(), MARGO_CLIENT_MODE);
             }
             else {
                 thallium_client = thallium_engine;
@@ -188,23 +148,10 @@ Response RPC::call(uint16_t server_index,
 
             // Setup args for RDMA bulk transfer
             // std::vector<std::pair<void*,std::size_t>> segments(num_args);
+            // tl::bulk bulk_handle = remote_procedure.on(server_endpoint)(std::forward<Args>(args)...);
+            // return std::make_pair(lookup_str, bulk_handle);
 
-            // We use addr lookup because mercury addresses must be exactly 15 char
-            char ip[16];
-            struct hostent *he = gethostbyname(server_list.at(server_index).c_str());
-            in_addr **addr_list = (struct in_addr **)he->h_addr_list;
-            strcpy(ip, inet_ntoa(*addr_list[0]));
-
-            CharStruct lookup_str = BASKET_CONF->VERBS_CONF + "://" + std::string(ip) + ":" + 
-	      std::to_string(port);
-            tl::endpoint server_endpoint = thallium_client->lookup(lookup_str.c_str());
-            // if (func_name == "test_Get") {
-            //     tl::bulk bulk_handle = remote_procedure.on(server_endpoint)(std::forward<Args>(args)...);
-            //     return std::make_pair(lookup_str, bulk_handle);
-            // }
-            // else {
-                return remote_procedure.on(server_endpoint)(std::forward<Args>(args)...);
-            // }
+            return remote_procedure.on(thallium_endpoints[server_index])(std::forward<Args>(args)...);
             break;
         }
 #endif
@@ -222,10 +169,9 @@ std::future<Response> RPC::async_call(uint16_t server_index,
     switch (BASKET_CONF->RPC_IMPLEMENTATION) {
 #ifdef BASKET_ENABLE_RPCLIB
         case RPCLIB: {
-            /* Connect to Server */
-            rpc::client client(server_list.at(server_index).c_str(), port);
+            auto *client = rpclib_clients[server_index].get();
             // client.set_timeout(5000);
-            return client.async_call(func_name.c_str(), std::forward<Args>(args)...);
+            return client->async_call(func_name.c_str(), std::forward<Args>(args)...);
             break;
         }
 #endif

--- a/include/basket/communication/rpc_lib.h
+++ b/include/basket/communication/rpc_lib.h
@@ -94,10 +94,15 @@ private:
     std::string name;
 #ifdef BASKET_ENABLE_RPCLIB
     std::shared_ptr<rpc::server> rpclib_server;
+    // We can't use a std::vector<rpc::client> for these since rpc::client is neither copy
+    // nor move constructible. See https://github.com/rpclib/rpclib/issues/128
+    std::vector<std::unique_ptr<rpc::client>> rpclib_clients;
 #endif
 #if defined(BASKET_ENABLE_THALLIUM_TCP) || defined(BASKET_ENABLE_THALLIUM_ROCE)
     std::shared_ptr<tl::engine> thallium_engine;
     CharStruct engine_init_str;
+    std::vector<tl::endpoint> thallium_endpoints;
+    void init_engine_and_endpoints(CharStruct conf);
     /*std::promise<void> thallium_exit_signal;
 
       void runThalliumServer(std::future<void> futureObj){

--- a/src/basket/communication/rpc_lib.cpp
+++ b/src/basket/communication/rpc_lib.cpp
@@ -33,16 +33,17 @@ RPC::~RPC() {
             case THALLIUM_TCP:
 #endif
 #ifdef BASKET_ENABLE_THALLIUM_ROCE
-                case THALLIUM_ROCE:
+            case THALLIUM_ROCE:
 #endif
 #if defined(BASKET_ENABLE_THALLIUM_TCP) || defined(BASKET_ENABLE_THALLIUM_ROCE)
             {
+                // Mercury addresses in endpoints must be freed before finalizing Thallium
+                thallium_endpoints.clear();
                 thallium_engine->finalize();
                 break;
             }
 #endif
         }
-
     }
 }
 
@@ -75,7 +76,7 @@ RPC::RPC() : server_list(),
       case THALLIUM_ROCE: {
 	  engine_init_str = BASKET_CONF->VERBS_CONF + "://" +
 	    BASKET_CONF->VERBS_DOMAIN + "://" +
-	    std::string(BASKET_CONF->SERVER_LIST[BASKET_CONF->MY_SERVER]) +
+	    BASKET_CONF->SERVER_LIST[BASKET_CONF->MY_SERVER] +
 	    ":" +
 	    std::to_string(server_port+BASKET_CONF->MY_SERVER);
 	  break;
@@ -86,27 +87,47 @@ RPC::RPC() : server_list(),
         switch (BASKET_CONF->RPC_IMPLEMENTATION) {
 #ifdef BASKET_ENABLE_RPCLIB
             case RPCLIB: {
-              break;
+                for (std::vector<rpc::client>::size_type i = 0; i < server_list.size(); ++i) {
+                    rpclib_clients.push_back(std::make_unique<rpc::client>(server_list[i].c_str(), server_port + i));
+                }
+                break;
             }
 #endif
 #ifdef BASKET_ENABLE_THALLIUM_TCP
-                case THALLIUM_TCP: {
-		  thallium_engine = basket::Singleton<tl::engine>::GetInstance(BASKET_CONF->TCP_CONF.c_str(),
-                                                                         MARGO_CLIENT_MODE);
-                    break;
-                }
+            case THALLIUM_TCP: {
+                init_engine_and_endpoints(BASKET_CONF->TCP_CONF);
+                break;
+            }
 #endif
 #ifdef BASKET_ENABLE_THALLIUM_ROCE
-                case THALLIUM_ROCE: {
-                  thallium_engine = basket::Singleton<tl::engine>::GetInstance(BASKET_CONF->VERBS_CONF.c_str(),
-                                           MARGO_CLIENT_MODE);
-                  break;
-                }
+            case THALLIUM_ROCE: {
+                init_engine_and_endpoints(BASKET_CONF->VERBS_CONF);
+                break;
+            }
 #endif
         }
     }
     run(BASKET_CONF->RPC_THREADS);
 }
+
+#if defined(BASKET_ENABLE_THALLIUM_TCP) || defined(BASKET_ENABLE_THALLIUM_ROCE)
+void RPC::init_engine_and_endpoints(CharStruct protocol) {
+    thallium_engine = basket::Singleton<tl::engine>::GetInstance(protocol.c_str(), MARGO_CLIENT_MODE);
+
+    thallium_endpoints.reserve(server_list.size());
+    for (std::vector<CharStruct>::size_type i = 0; i < server_list.size(); ++i) {
+        // We use addr lookup because mercury addresses must be exactly 15 char
+        char ip[16];
+        struct hostent *he = gethostbyname(server_list[i].c_str());
+        in_addr **addr_list = (struct in_addr **)he->h_addr_list;
+        strcpy(ip, inet_ntoa(*addr_list[0]));
+
+        CharStruct lookup_str = protocol + "://" + std::string(ip) + ":" +
+            std::to_string(server_port + i);
+        thallium_endpoints.push_back(thallium_engine->lookup(lookup_str.c_str()));
+    }
+}
+#endif
 
 void RPC::run(size_t workers) {
     AutoTrace trace = AutoTrace("RPC::run", workers);


### PR DESCRIPTION
Closes #11, fixes #9. The `RPC` constructor creates a list of connections (clients for `rpclib` and endpoints for `thallium`) for each server and reuses them instead of creating one for each request. I built and ran the tests for each configuration (`RPCLIB`, `THALLIUM_TCP`, `THALLIUM_ROCE`). In addition to solving the problem of running out of ports, this also gives us a nice speedup:

Op | RPC |  0.0.3 | This branch | Speedup
---  | ---- | ----- | ------------- | ----------
put | rpclib | 1.19 | 2.15 |1.8
get | rpclib | 1.09 | 1.54 | 1.40
put | thallium | 8.59 | 15.39 | 1.79
get | thallium | 8.74 | 16.15 | 1.85

@hariharan-devarajan 