### PR TITLE
Work in progress: Thallium bulk transfer interface

### DIFF
--- a/include/basket/communication/rpc_lib.cpp
+++ b/include/basket/communication/rpc_lib.cpp
@@ -205,7 +205,7 @@ Response RPC::bulk_call_put(uint16_t server_index, CharStruct const &func_name, 
 }
 
 template <typename Response, typename KeyType>
-Response RPC::bulk_call_get(uint16_t server_index, CharStruct const &func_name, KeyType &key) {
+Response RPC::bulk_call_get(uint16_t server_index, CharStruct const &func_name, KeyType &key, size_t buf_size) {
     AutoTrace trace = AutoTrace("RPC::bulk_call_get", server_index, func_name);
     int16_t port = server_port + server_index;
 
@@ -222,14 +222,7 @@ Response RPC::bulk_call_get(uint16_t server_index, CharStruct const &func_name, 
 
     tl::remote_procedure remote_procedure = thallium_client->define(func_name.c_str());
 
-    // Serialize an empty result in a buffer_output_archive. Note, this won't
-    // work for variable sized containers. We would have to make a request to
-    // get the size first.
-    tl::buffer buf;
-    tl::buffer_output_archive archive(buf);
-    Response result;
-    archive & result;
-
+    tl::buffer buf(buf_size);
     std::vector<std::pair<void*, std::size_t>> segments(1);
     segments[0].first  = buf.data();
     segments[0].second = buf.size();
@@ -238,6 +231,7 @@ Response RPC::bulk_call_get(uint16_t server_index, CharStruct const &func_name, 
 
     // Deserialize result
     tl::buffer_input_archive in_archive(buf);
+    Response result;
     in_archive & result;
 
     return result;

--- a/include/basket/communication/rpc_lib.h
+++ b/include/basket/communication/rpc_lib.h
@@ -130,7 +130,7 @@ private:
     Response bulk_call_put(uint16_t server_index, CharStruct const &func_name, KeyType &key, ValueType &val);
 
     template <typename Response, typename KeyType>
-    Response bulk_call_get(uint16_t server_index, CharStruct const &func_name, KeyType &key);
+    Response bulk_call_get(uint16_t server_index, CharStruct const &func_name, KeyType &key, size_t size);
 
     template<typename MappedType>
     MappedType prep_rdma_server(tl::endpoint endpoint, tl::bulk &bulk_handle);

--- a/include/basket/communication/rpc_lib.h
+++ b/include/basket/communication/rpc_lib.h
@@ -123,7 +123,15 @@ private:
 
     void run(size_t workers = RPC_THREADS);
 
-#ifdef BASKET_ENABLE_THALLIUM_ROCE
+#if defined(BASKET_ENABLE_THALLIUM_TCP) || defined(BASKET_ENABLE_THALLIUM_ROCE)
+    std::shared_ptr<tl::engine> get_engine();
+
+    template <typename Response, typename KeyType, typename ValueType>
+    Response bulk_call_put(uint16_t server_index, CharStruct const &func_name, KeyType &key, ValueType &val);
+
+    template <typename KeyType, typename ValueType>
+    std::pair<bool, ValueType> bulk_call_get(uint16_t server_index, CharStruct const &func_name, KeyType &key);
+
     template<typename MappedType>
     MappedType prep_rdma_server(tl::endpoint endpoint, tl::bulk &bulk_handle);
 

--- a/include/basket/communication/rpc_lib.h
+++ b/include/basket/communication/rpc_lib.h
@@ -129,8 +129,8 @@ private:
     template <typename Response, typename KeyType, typename ValueType>
     Response bulk_call_put(uint16_t server_index, CharStruct const &func_name, KeyType &key, ValueType &val);
 
-    template <typename KeyType, typename ValueType>
-    std::pair<bool, ValueType> bulk_call_get(uint16_t server_index, CharStruct const &func_name, KeyType &key);
+    template <typename Response, typename KeyType>
+    Response bulk_call_get(uint16_t server_index, CharStruct const &func_name, KeyType &key);
 
     template<typename MappedType>
     MappedType prep_rdma_server(tl::endpoint endpoint, tl::bulk &bulk_handle);

--- a/include/basket/unordered_map/unordered_map.cpp
+++ b/include/basket/unordered_map/unordered_map.cpp
@@ -151,7 +151,7 @@ bool unordered_map<KeyType, MappedType>::LocalPut(KeyType &key,
                                                   MappedType &data) {
     boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex>lock(*mutex);
     myHashMap->insert_or_assign(key, data);
-    MappedType result = myHashMap->at(key);
+
     return true;
 }
 /**

--- a/include/basket/unordered_map/unordered_map.h
+++ b/include/basket/unordered_map/unordered_map.h
@@ -127,23 +127,13 @@ class unordered_map {
     std::vector<std::pair<KeyType, MappedType>> LocalGetAllDataInServer();
 
 #if defined(BASKET_ENABLE_THALLIUM_TCP) || defined(BASKET_ENABLE_THALLIUM_ROCE)
+    bool BulkPut(KeyType &key, MappedType &val);
+    std::pair<bool, MappedType> BulkGet(KeyType &key);
+
+    void ThalliumBulkPut(const tl::request &thallium_req, tl::bulk &bulk_handle, KeyType &key);
+    void ThalliumBulkGet(const tl::request &thallium_req, tl::bulk &bulk_handle, KeyType &key);
+
     THALLIUM_DEFINE(LocalPut, (key,data) ,KeyType &key, MappedType &data)
-
-    // void ThalliumLocalPut(const tl::request &thallium_req, tl::bulk &bulk_handle, KeyType key) {
-    //     MappedType data = rpc->prep_rdma_server<MappedType>(thallium_req.get_endpoint(), bulk_handle);
-    //     thallium_req.respond(LocalPut(key, data));
-    // }
-
-    // void ThalliumLocalGet(const tl::request &thallium_req, KeyType key) {
-    //     auto retpair = LocalGet(key);
-    //     if (!retpair.first) {
-    //         printf("error\n");
-    //     }
-    //     MappedType data = retpair.second;
-    //     tl::bulk bulk_handle = rpc->prep_rdma_client<MappedType>(data);
-    //     thallium_req.respond(bulk_handle);
-    // }
-
     THALLIUM_DEFINE(LocalGet, (key), KeyType &key)
     THALLIUM_DEFINE(LocalErase, (key), KeyType &key)
     THALLIUM_DEFINE1(LocalGetAllDataInServer)

--- a/include/basket/unordered_map/unordered_map.h
+++ b/include/basket/unordered_map/unordered_map.h
@@ -129,10 +129,12 @@ class unordered_map {
 #if defined(BASKET_ENABLE_THALLIUM_TCP) || defined(BASKET_ENABLE_THALLIUM_ROCE)
     bool BulkPut(KeyType &key, MappedType &val);
     std::pair<bool, MappedType> BulkGet(KeyType &key);
+    size_t GetBulkSize(KeyType &key);
 
     void ThalliumBulkPut(const tl::request &thallium_req, tl::bulk &bulk_handle, KeyType &key);
     void ThalliumBulkGet(const tl::request &thallium_req, tl::bulk &bulk_handle, KeyType &key);
 
+    THALLIUM_DEFINE(GetBulkSize, (key), KeyType &key)
     THALLIUM_DEFINE(LocalPut, (key,data) ,KeyType &key, MappedType &data)
     THALLIUM_DEFINE(LocalGet, (key), KeyType &key)
     THALLIUM_DEFINE(LocalErase, (key), KeyType &key)

--- a/src/basket/communication/rpc_lib.cpp
+++ b/src/basket/communication/rpc_lib.cpp
@@ -111,6 +111,10 @@ RPC::RPC() : server_list(),
 }
 
 #if defined(BASKET_ENABLE_THALLIUM_TCP) || defined(BASKET_ENABLE_THALLIUM_ROCE)
+std::shared_ptr<tl::engine> RPC::get_engine() {
+    return thallium_engine;
+}
+
 void RPC::init_engine_and_endpoints(CharStruct protocol) {
     thallium_engine = basket::Singleton<tl::engine>::GetInstance(protocol.c_str(), MARGO_CLIENT_MODE);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # target_link_libraries(DistributedHashMapTest ${CMAKE_BINARY_DIR}/libbasket.so)
 
-set(examples unordered_map_test map_test queue_test priority_queue_test multimap_test set_test)
+set(examples unordered_map_test map_test queue_test priority_queue_test multimap_test set_test thallium_bulk_test)
 # global_clock_test global_sequence_test
 
 add_custom_target(copy_hostfile)
@@ -24,6 +24,7 @@ foreach (example ${examples})
     add_dependencies(${example} copy_hostfile)
     add_dependencies(${example} copy_server_list)
     set_target_properties(${example} PROPERTIES ENVIRONMENT LD_PRELOAD=${CMAKE_BINARY_DIR}/libbasket.so)
+    target_include_directories(${example} PRIVATE ".")
     target_link_libraries(${example} ${PROJECT_NAME})
     set_target_properties (${example} PROPERTIES FOLDER test)
 endforeach()

--- a/test/thallium_bulk_test.cpp
+++ b/test/thallium_bulk_test.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2019  Chris Hogan
+ *
+ * This file is part of Basket
+ *
+ * Basket is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <cassert>
+#include <cstdlib>
+#include <ctime>
+
+#include <mpi.h>
+#include "util.h"
+#include <basket/unordered_map/unordered_map.h>
+
+int main (int argc, char* argv[])
+{
+    MpiData mpi = initMpiData(&argc, &argv);
+
+    if (mpi.comm_size != 2) {
+        fprintf(stderr, "thallium_bulk_test is meant to be run with 2 MPI processes\n");
+        exit(EXIT_FAILURE);
+    }
+
+    int num_requests = 1;
+    bool is_server = mpi.rank == mpi.comm_size - 1;
+
+    BASKET_CONF->IS_SERVER = is_server;
+    BASKET_CONF->MY_SERVER = 0;
+    BASKET_CONF->NUM_SERVERS = 1;
+    BASKET_CONF->SERVER_ON_NODE = is_server;
+    BASKET_CONF->SERVER_LIST_PATH = "./server_list";
+
+    constexpr int array_size= 1000;
+    constexpr size_t size_of_elem = sizeof(array_size);
+    using MyArray = std::array<int, array_size>;
+    using MyMap = basket::unordered_map<KeyType, MyArray>;
+
+    MyMap *map;
+    CharStruct shm_name("THALLIUM_BULK_TEST");
+    if (is_server) {
+        map = new MyMap(shm_name);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (!is_server) {
+        map = new MyMap(shm_name);
+    }
+
+    if (!is_server) {
+        for(int i = 0; i < num_requests; ++i) {
+            size_t val = i;
+            auto key = KeyType(val);
+            MyArray arr;
+            for (auto &x : arr) {
+                x = 5;
+            }
+            std::cout << "Put " << i << "\n";
+            map->BulkPut(key, arr);
+        }
+
+        for(int i = 0; i < num_requests; ++i) {
+            size_t val = i;
+            auto key = KeyType(val);
+            std::cout << "Get " << i << "\n";
+            auto result = map->BulkGet(key);
+            assert(result.first);
+            MyArray arr = result.second;
+            assert(arr.size() == array_size);
+            for (const auto &x : arr) {
+                assert(x == 5);
+            }
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    delete(map);
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/thallium_bulk_test.cpp
+++ b/test/thallium_bulk_test.cpp
@@ -72,8 +72,11 @@ int main (int argc, char* argv[])
     using MyArray = std::array<int, array_size>;
     using MyMap = basket::unordered_map<KeyType, MyArray>;
 
+    char *username = std::getenv("USER");
+    std::string shm_string = std::string(username ? username : "") + "_THALLIUM_BULK_TEST";
+    CharStruct shm_name(shm_string);
+
     MyMap *map;
-    CharStruct shm_name("THALLIUM_BULK_TEST");
     if (is_server) {
         map = new MyMap(shm_name);
     }


### PR DESCRIPTION
This needs some discussion before being merged. 

Current limitations:
* Only implemented for `unordered_map`
* ~`BulkGet` only supports fixed-sized data types (`std::array` being the only container in this category). Supporting variable sized containers just requires an extra request to get the size.~
* Extra copying for serialization may defeat the purpose of bulk transfers